### PR TITLE
Remember full screen

### DIFF
--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -30,6 +30,8 @@ import type { Config } from './types'
 //   autoPlay: true,
 // })
 
+
+// These set the default config values
 const createConfig = () => {
   const { subscribe, set, update } = writable<Config>({
     autoSync: true,
@@ -37,6 +39,7 @@ const createConfig = () => {
     autoHideText: 8,
     autoCycle: 60,
     autoPlay: true,
+    startInFullScreen: false
   })
 
   const updateProp = (key: keyof Config, value) => {

--- a/src/model/persistence.ts
+++ b/src/model/persistence.ts
@@ -2,6 +2,8 @@ import { isEqual } from 'lodash'
 
 import { wallet, synced, assets } from './store'
 import { config } from './config'
+import { get } from 'svelte/store'
+import { ui } from './ui'
 
 import {
   loadStorage,
@@ -26,6 +28,10 @@ export const initialize = async () => {
     }
     if (data.config) {
       config.set(data.config)
+
+      // Check config for "startInFullScreen"
+      // console.log('start in fullscreen:', get(config).startInFullScreen);
+      if (get(config).startInFullScreen) { ui.isFullScreen.update(isFS => !isFS) }
     }
 
     createPersistence()

--- a/src/model/persistence.ts
+++ b/src/model/persistence.ts
@@ -31,7 +31,7 @@ export const initialize = async () => {
 
       // Check config for "startInFullScreen"
       // console.log('start in fullscreen:', get(config).startInFullScreen);
-      if (get(config).startInFullScreen) { ui.isFullScreen.update(isFS => !isFS) }
+      if (get(config).startInFullScreen) { ui.isFullScreen.set(get(config).startInFullScreen) }
     }
 
     createPersistence()

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -51,4 +51,5 @@ export type Config = {
   autoHideText: number
   autoCycle: number
   autoPlay: boolean
+  startInFullScreen: boolean
 }

--- a/src/model/ui.ts
+++ b/src/model/ui.ts
@@ -12,10 +12,9 @@ export const ui = {
   showAllControls,
   showAllText,
   isAboveArt,
-  isFullScreen,
-  showSettings
+  showSettings,
+  isFullScreen
 }
-
 
 
 // Persist certain settings in storage...

--- a/src/newtab/Frame.svelte
+++ b/src/newtab/Frame.svelte
@@ -114,7 +114,7 @@
   // }
 
   const dispatch = action => {
-    console.log('dispatch', action);
+    // console.log('dispatch', action);
     
     switch (action) {
       case 'LEFT':

--- a/src/newtab/SettingsPanel.svelte
+++ b/src/newtab/SettingsPanel.svelte
@@ -67,6 +67,10 @@
     <label for=autoPlay>auto play audio & video</label>
     <input type=checkbox name=autoPlay id=autoPlay bind:checked={$config.autoPlay} />
   </li>
+  <li>
+    <label for=startInFullScreen>start artsee with fullscreen NFTs</label>
+    <input type=checkbox name=startInFullScreen id=startInFullScreen bind:checked={$config.startInFullScreen} />
+  </li>
 </ul>
 <ul>
   <li>


### PR DESCRIPTION
Added checkbox selection to settings to start artsee with full screen NFTs.

![Screenshot 2022-01-07 162756](https://user-images.githubusercontent.com/29826275/148609719-1f757df7-890f-41a5-984e-8789077640c7.png)

Updated `Config` type in `types.ts` and added it to `config.ts`.

On initialization, after checking and loading the config from chrome storage, the program will check if "startInFullScreen" is true and update it in the UI.

Let me know if there's anything I should change!